### PR TITLE
environment-aware `npm start`

### DIFF
--- a/bin/start.sh
+++ b/bin/start.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ "$NODE_ENV" == "production" ]; then
+  node index.js
+else
+  nodemon -e js,hbs,md,json
+fi

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The place where all things npm will one day be documented",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js",
+    "start": "npm run build && bin/start.sh",
     "postinstall": "npm run build",
     "build": "bin/build.sh"
   },
@@ -36,5 +36,8 @@
     "npm": "latest",
     "strftime": "^0.8.2",
     "walkdir": "0.0.7"
+  },
+  "devDependencies": {
+    "nodemon": "^1.2.1"
   }
 }

--- a/service.json
+++ b/service.json
@@ -6,7 +6,8 @@
       "start": "node index.js"
     },
     "env": {
-      "PORT": "8081"
+      "PORT": "8081",
+      "NODE_ENV": "production"
     }
   },
   "docs2": {
@@ -16,7 +17,8 @@
       "start": "node index.js"
     },
     "env": {
-      "PORT": "8082"
+      "PORT": "8082",
+      "NODE_ENV": "production"
     }
   }
 }


### PR DESCRIPTION
This is a pattern I learned at Heroku for making `npm start` do the right thing depending on your environment.

I know this change won't interfere with deployments today because `ndm` doesn't currently use `npm start`, but I want @ceejbot and @bcoe to see this anyway. What do you guys think? How would I set `NODE_ENV` to "production" in `service.json`?

cc @rockbot, who might want to do this in newww too.

