### PR TITLE
All the Docs!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ content/api/
 content/cli/
 content/files/
 content/misc/
+content/policies/
 content.json
 content.lite.json

--- a/README.md
+++ b/README.md
@@ -68,5 +68,12 @@ documentation and accompanying metadata with a single HTTP call.
 ## Deployment
 
 ```sh
-export NODE_ENV=production
+git push origin +master:deploy-staging
+git push origin +master:deploy-production
+```
+
+If you get dissed with an "Everything up-to-date" message, make an empty commit and push again:
+
+```
+git commit -avm "emptiness" --allow-empty
 ```

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -6,6 +6,7 @@ rm -rf content/api
 rm -rf content/cli
 rm -rf content/files
 rm -rf content/misc
+
 rm -rf content/policies
 
 # The -p flag preserves file timestamps
@@ -13,6 +14,7 @@ cp -pr node_modules/npm/doc/api content/
 cp -pr node_modules/npm/doc/cli content/
 cp -pr node_modules/npm/doc/files content/
 cp -pr node_modules/npm/doc/misc content/
+
 cp -pr node_modules/@npm/policies content/
 
 ./bin/tree.js

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -6,10 +6,13 @@ rm -rf content/api
 rm -rf content/cli
 rm -rf content/files
 rm -rf content/misc
+rm -rf content/policies
 
+# The -p flag preserves file timestamps
 cp -pr node_modules/npm/doc/api content/
 cp -pr node_modules/npm/doc/cli content/
 cp -pr node_modules/npm/doc/files content/
 cp -pr node_modules/npm/doc/misc content/
+cp -pr node_modules/@npm/policies content/
 
 ./bin/tree.js

--- a/bin/tree.js
+++ b/bin/tree.js
@@ -19,16 +19,7 @@ var contentFile = path.resolve(__dirname, "../content.json")
 
 // Flesh out the content object
 var content = {
-  sections: [
-    {id: "getting-started", title: "Getting Started"},
-    {id: "misc", title: "Using npm"},
-    {id: "enterprise", title: "npm Enterprise"},
-    {id: "cli", title: "CLI Commands"},
-    {id: "files", title: "Configuring npm"},
-    {id: "api", title: "Using npm programmatically"},
-    {id: "policies", title: "npm policy documents"},
-    {id: "company", title: "About npm inc"},
-  ],
+  sections: require("../sections.json"),
   pages: []
 }
 

--- a/bin/tree.js
+++ b/bin/tree.js
@@ -45,6 +45,10 @@ emitter.on("file", function(filepath,stat){
     content: fs.readFileSync(filepath).toString()
   }
 
+  // Get modified date
+  page.modified = fs.statSync(filepath).mtime
+  page.modifiedPretty = strftime("%B %d, %Y", page.modified)
+
   // Look for HTML frontmatter
   merge(page, frontmatter(page.content))
 
@@ -56,11 +60,7 @@ emitter.on("file", function(filepath,stat){
     page.content = page.content.replace(manHead[0], "")
   }
 
-  // Get modified date
-  page.modified = fs.statSync(filepath).mtime
-  page.modifiedPretty = strftime("%B %d, %Y", page.modified)
-
-  // Titlecase some things
+  // Titlecase some headings from the npm/npm docs
   page.content = page.content
     .replace(/## SYNOPSIS/g, "## Synopsis")
     .replace(/## DESCRIPTION/g, "## Description")
@@ -69,16 +69,6 @@ emitter.on("file", function(filepath,stat){
 
   // Convert markdown to HTML
   page.content = marky(page.content).html()
-
-  // Remove basepath and extension from filename
-  page.filename = page.filename
-    .replace(/.*\/content\//, "")
-    .replace(/\.md$/, "")
-
-  // Use filename as title if not specified in frontmatter
-  // (and remove superfluous npm- prefix)
-  if (!page.title)
-    page.title = path.basename(page.filename).replace(/^npm-/, "")
 
   // Infer section from top directory
   if (page.filename.match(/\//))
@@ -97,7 +87,7 @@ emitter.on("file", function(filepath,stat){
     .replace(/\/npm-/, "/")
     .replace(/\.md$/, "")
 
-  // Use filename as title if not specified in frontmatter
+  // Use href as title if not specified in frontmatter
   if (!page.title) {
     page.title = path.basename(page.href)
   }

--- a/bin/tree.js
+++ b/bin/tree.js
@@ -26,6 +26,8 @@ var content = {
     {id: "cli", title: "CLI Commands"},
     {id: "files", title: "Configuring npm"},
     {id: "api", title: "Using npm programmatically"},
+    {id: "policies", title: "npm policy documents"},
+    {id: "company", title: "About npm inc"},
   ],
   pages: []
 }

--- a/bin/tree.js
+++ b/bin/tree.js
@@ -68,7 +68,7 @@ emitter.on("file", function(filepath,stat){
     .replace(/## SEE ALSO/g, "## See Also")
 
   // Convert markdown to HTML
-  page.content = marky(page.content).html()
+  page.content = marky(page.content, {sanitize: false}).html()
 
   // Infer section from top directory
   if (page.filename.match(/\//))

--- a/bin/tree.js
+++ b/bin/tree.js
@@ -5,16 +5,18 @@
 
 var path        = require("path")
 var fs          = require("fs")
-var marked      = require("marked")
 var fmt         = require("util").format
 var strftime    = require("strftime")
 var cheerio     = require("cheerio")
+var marky       = require("marky-markdown")
+var frontmatter = require("html-frontmatter")
 var _           = require("lodash")
+
 var compact     = _.compact
 var uniq        = _.uniq
 var pluck       = _.pluck
 var merge       = _.merge
-var frontmatter          = require("html-frontmatter")
+
 var contentFile = path.resolve(__dirname, "../content.json")
 
 // Flesh out the content object
@@ -66,28 +68,17 @@ emitter.on("file", function(filepath,stat){
     .replace(/## SEE ALSO/g, "## See Also")
 
   // Convert markdown to HTML
-  page.content = marked(page.content)
-
-  // Wrap YouTube videos so they can be styled.
-  var $ = cheerio.load(page.content)
-  $('iframe[src*="youtube.com"]').each(function(i, elem) {
-    $(this).removeAttr("width")
-    $(this).removeAttr("height")
-    $(this).before(fmt("<div class='youtube-video'>%s</div>", $(this).toString()));
-    $(this).remove()
-  });
-
-  page.content = $.html()
+  page.content = marky(page.content).html()
 
   // Remove basepath and extension from filename
-  filename = filename
+  page.filename = page.filename
     .replace(/.*\/content\//, "")
     .replace(/\.md$/, "")
 
   // Use filename as title if not specified in frontmatter
   // (and remove superfluous npm- prefix)
   if (!page.title)
-    page.title = path.basename(filename).replace(/^npm-/, "")
+    page.title = path.basename(page.filename).replace(/^npm-/, "")
 
   // Infer section from top directory
   if (page.filename.match(/\//))

--- a/content/company/about.md
+++ b/content/company/about.md
@@ -1,0 +1,30 @@
+# About npm
+
+npm is lots of things.
+
+* npm is the package manager for [Node.js](http://nodejs.org/).  It was created in 2009 as an [open source project](https://github.com/npm/npm) to help JavaScript developers easily share packaged modules of code.
+* The npm Registry is a public collection of packages of open-source code for Node.js, [front-end web apps](http://www.ember-cli.com/), [mobile apps](http://cordova.apache.org/), [robots](https://tessel.io/), [routers](https://linerate.f5.com/), and countless other needs of the JavaScript community.
+* npm is the command line client that allows developers to install and publish those packages.
+* npm, Inc. is the company that hosts and maintains all of the above.
+
+## About npm, Inc.
+
+npm, Inc. is a company co-founded in 2014 by npm's creator, Isaac Z. Schlueter, along with Laurie Voss and Rod Boothby.
+
+npm, Inc. is dedicated to the long term success of the JavaScript community, which includes the success of the open-source Node.js and npm projects.
+
+At npm, Inc. we do three things to support this goal:
+
+1. Run the open source registry as a free service.
+2. Build tools and operate services that support the secure use of packages in a private or enterprise context.
+3. Build innovative new tools and services for the developer community.
+
+npm's mission is to take Open Source development to entirely new places. When everyone else is adding force, we work to reduce friction.
+
+npm is not a typical product, and we are not a typical "work hard/play hard" startup. We are responsible adults with diverse backgrounds and interests, who take our careers and our lives seriously. We believe that the best way to iterate towards success is by taking care of ourselves, our families, our users, and one another. We aim for a sustainable approach to work and life, because that is the best way to maximize long-term speed, while retaining clarity of vision. Compassion is our strategy.
+
+Our offices are in downtown Oakland, California.
+
+## Contacting npm
+
+You can reach us for support or any other questions via our [contact form](/support) or at [npm@npmjs.com](mailto:npm@npmjs.com).

--- a/content/company/jobs.md
+++ b/content/company/jobs.md
@@ -1,8 +1,25 @@
 # Nice People Matter: npm is hiring
 
-We are not currently hiring for any specific positions. If you would like to work with us and have skills you think would be helpful, please send an email with evidence of your experience (like your resume, or links to LinkedIn/GitHub/wherever) to jobs@npmjs.com.
+We currently are looking for interns to join us in summer 2015. Even if that's not what you're looking for, if you would like to work with us and have skills you think would be helpful, please send an email with evidence of your experience (like your resume, or links to LinkedIn/GitHub/wherever) to jobs@npmjs.com.
 
 We’d like to hear from you.
+
+## Internships
+
+If you're currently in full-time education (class of 2016 or 2017) and looking for a summer internship with an open-source project that can also pay you, we're happy to say that we can offer you a place at npm in partnership with our investors, as part of the [True Entrepreneur Corps](http://www.trueventures.com/tec/) program.
+
+We are looking primarily for enthusiasm and intellectual curiosity, but any experience with JavaScript and especially Node.js is obviously a big advantage.
+
+You'll be working on the open-source npm project itself, so your work will be code-reviewed by the same people who run the project, your commits will immediately benefit tens of thousands of active users, and will also be publicly verifiable by future employers.
+
+Last year's intern, [Faiq](https://twitter.com/faiqus), wrote about [what he learned](http://www.trueventurestec.com/2014/06/26/some-useful-info-for-tech-interns/) on TEC's blog and also had this to say:
+
+> Imagine working at a place with some of the best and kindest engineers, getting paid to write open source code, and being immersed in one of the most diverse developer communities ever. It sounds too good to be true, doesn't it? When you get a chance to work at npm, you'll be doing exactly that. Day to day, you'll get to work on challenging problems that push your limits as an engineer. You'll run into problems that'll seem impossible at first, but by the end of your internship will seem like a piece of cake! This internship is one of the most unique opportunities you'll get, so definitely give it a shot and apply!
+
+Faiq worked on our website and search. Even after leaving npm, Faiq continues to be involved and has even [committed to npm core](https://github.com/npm/npm/commits/master?author=faiq). You can expect a similar range of opportunities, depending on your interests.
+
+If you're interested, please send a brief email introducing yourself as well as a PDF or Google doc of your resume to [jobs@npmjs.com](mailto:jobs@npmjs.com) and include the word "internship" in your subject line. The internship is based out of our offices in Oakland, California. You must be part of the graduating class of 2016 or 2017 and legally able to work in the United States; we are not currently able to sponsor visa applications.
+
 
 ## About npm, Inc.
 

--- a/content/company/jobs.md
+++ b/content/company/jobs.md
@@ -1,0 +1,15 @@
+# Nice People Matter: npm is hiring
+
+We are not currently hiring for any specific positions. If you would like to work with us and have skills you think would be helpful, please send an email with evidence of your experience (like your resume, or links to LinkedIn/GitHub/wherever) to jobs@npmjs.com.
+
+We’d like to hear from you.
+
+## About npm, Inc.
+
+npm is the package manager for JavaScript. The team is small, and growing quickly. If you join us, you will see the company grow through numerous changes, and take a bunch of different roles.
+
+npm’s mission is to take Open Source development to entirely new places. When everyone else is adding force, we work to reduce friction.
+
+npm is not a typical product, and we are not a typical early-stage “work hard/play hard” startup. We are responsible adults with diverse backgrounds and interests, who take our careers and our lives seriously. We believe that the best way to iterate towards success is by taking care of ourselves, our families, our users, and one another. We aim for a sustainable approach to work and life, because that is the best way to maximize long-term speed, while retaining clarity of vision. Compassion is our strategy.
+
+[Our offices](https://www.google.com/maps/place/200+Frank+H+Ogawa+Plaza/@37.805544,-122.2720659,17z/data=!3m1!4b1!4m2!3m1!1s0x808f80b1a2db786f:0x4685356d4acb43ef) are in downtown Oakland, California. We offer very competitive salaries, meaningful equity, and generous health, dental and vision benefits. We love it when you represent us at conferences.

--- a/content/company/npm-weekly.md
+++ b/content/company/npm-weekly.md
@@ -1,0 +1,31 @@
+<hgroup>
+  <h1>npm Weekly</h1>
+  <h2>Find out what we've been working on, thinking about, and talking about every week.</h2>
+</hgroup>
+
+<form action="//npmjs.us9.list-manage.com/subscribe/post?u=077dfd41302a71310cef619e5&amp;id=e17fe5d778" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+
+  <label for="mce-EMAIL">Email Address</label>
+  <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL" required="required" autocorrect="off" autocapitalize="off">
+
+  <div id="mce-responses" class="clear">
+    <div class="response" id="mce-error-response" style="display:none"></div>
+    <div class="response" id="mce-success-response" style="display:none"></div>
+  </div>
+
+  <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+  <div style="position: absolute; left: -5000px;">
+    <input type="text" name="b_077dfd41302a71310cef619e5_e17fe5d778" tabindex="-1" value="">
+  </div>
+
+  <div class="clear">
+    <input type="submit" value="subscribe to the weekly" class="full-width" name="subscribe" id="mc-embedded-subscribe" class="button">
+  </div>
+
+</form>
+
+<script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script>
+
+<p>
+  Did you miss one? Check out the <a href="http://us9.campaign-archive2.com/home/?u=077dfd41302a71310cef619e5&id=e17fe5d778" title="View previous campaigns">npm weekly archive</a>.
+</p>

--- a/content/company/private-npm-thanks.md
+++ b/content/company/private-npm-thanks.md
@@ -1,0 +1,3 @@
+# Thanks for signing up private npm!
+
+We'll get in touch when private npm modules are available for beta testing.

--- a/content/company/private-npm.md
+++ b/content/company/private-npm.md
@@ -1,0 +1,53 @@
+<hgroup>
+<h1>npm Private Modules</h1>
+<h2>Publish, share and install proprietary code easily</h2>
+</hgroup>
+
+Private modules are ordinary npm packages that only you, and people you select,
+can view, install, and publish. You publish them in your namespace or your team's namespace, just by giving them a name in package.json:
+
+```json
+{
+  "name": "@myuser/mypackage"
+}
+```
+
+You publish them with `npm publish`, just like any other package, and you install
+them by name:
+
+```sh
+npm install @myuser/mypackage
+```
+
+Once installed, use them by requiring them by name, just like any package:
+
+```js
+var mypackage = require('@myuser/mypackage');
+```
+
+## Re-use your code
+
+You re-use code between projects. npm and the registry make it really easy to
+share small modules of useful code with the world. But sometimes the code in that
+package is private, or sensitive, or just too specific to your needs for you to
+want to publish it to the public registry. Private packages are great for this.
+
+## Share proprietary code
+
+You work in a team, or you work for clients. You want to be able to easily share
+your work, with the dependency management and version management that npm provides.
+By making it easy and granular to select who can see, install and publish packages,
+private packages make this easy.
+
+## Coming soon
+
+npm Private Modules are coming in early 2015.
+
+If you would like early access to the beta of npm Private Modules, you can sign up right now and we'll let you know
+when they are available.
+
+<script charset="utf-8" src="//js.hsforms.net/forms/current.js"></script>
+<div id="private-module-signup-form"></div>
+
+(We will not use this email address to do anything other than notify you of
+the beta of npm Private Modules, and when private packages become globally available)

--- a/content/company/security.md
+++ b/content/company/security.md
@@ -1,0 +1,37 @@
+# Security
+
+Need to report a security vulnerability? Please [contact us](/support) or email [security@npmjs.com](mailto:security@npmjs.com).
+
+## System Security
+
+Our engineering team is well-versed in security best practices.
+
+Our software is regularly audited by reputable third-party security firms, currently [Lift Security](https://liftsecurity.io/).
+
+We maintain a recent, production-ready OS that is regularly patched with the latest security fixes.
+
+Our servers live behind a firewall that only allows expected traffic on limited ports.
+
+Our services are fronted by a CDN that allows for protection from Distributed Denial of Service (DDoS) attacks.
+
+## Security in Transit
+
+All private data exchanged with npm from the command line and via the website is passed over encrypted connections (HTTPS and SSL).
+
+## Physical and Data Security
+
+npm's servers are hosted on Amazon Web Services. Physical security is maximized because nobody knows exactly which physical servers host our virtual ones.
+
+All registry data and binaries are stored in multiple redundant, physically separate locations. All binaries and metadata are backed up to a third-party, off-site location. These backups are encrypted.
+
+Employees of npm Inc. have access to package metadata and binaries for support and debugging purposes. Employees do not have access to the password for your npm account, which is always encrypted.
+
+For more information about how we handle your personal data, you may wish to review our [privacy policy](https://npmjs.com/policies/privacy).
+
+## Higher Levels of security
+
+For firms interested in greater levels of physical and operational security, [npm Enterprise](/enterprise) is a self-hosted version of the npm Registry that allows total control of the operation and policies of the registry.
+
+## Contact Us
+
+If you have further questions or concerns about npm security, please [contact us](mailto:security@npmjs.com).

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/npm/docs.npmjs.com",
   "dependencies": {
+    "@npm/policies": "git://github.com/npm/policies",
     "cors": "^2.4.2",
     "express": "^4.9.5",
     "handlebars-helper-equal": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "js-beautify": "^1.5.2",
     "leven": "^1.0.1",
     "lodash": "^2.4.1",
-    "marky-markdown": "^1.1.0",
+    "marky-markdown": "^4.0.0",
     "npm": "latest",
     "strftime": "^0.8.2",
     "walkdir": "0.0.7"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "js-beautify": "^1.5.2",
     "leven": "^1.0.1",
     "lodash": "^2.4.1",
-    "marked": "^0.3.2",
+    "marky-markdown": "^1.1.0",
     "npm": "latest",
     "strftime": "^0.8.2",
     "walkdir": "0.0.7"

--- a/sections.json
+++ b/sections.json
@@ -21,5 +21,6 @@
   "title": "npm policy documents"
 }, {
   "id": "company",
-  "title": "npm, the Company"
+  "title": "npm, the Company",
+  "ignoreOnHomepage": true
 }]

--- a/sections.json
+++ b/sections.json
@@ -1,7 +1,7 @@
 [{
   "id": "getting-started",
   "title": "Getting Started"
-} {
+}, {
   "id": "misc",
   "title": "Using npm"
 }, {

--- a/sections.json
+++ b/sections.json
@@ -21,5 +21,5 @@
   "title": "npm policy documents"
 }, {
   "id": "company",
-  "title": "About npm inc"
+  "title": "npm, the Company"
 }]

--- a/sections.json
+++ b/sections.json
@@ -1,0 +1,25 @@
+[{
+  "id": "getting-started",
+  "title": "Getting Started"
+} {
+  "id": "misc",
+  "title": "Using npm"
+}, {
+  "id": "enterprise",
+  "title": "npm Enterprise"
+}, {
+  "id": "cli",
+  "title": "CLI Commands"
+}, {
+  "id": "files",
+  "title": "Configuring npm"
+}, {
+  "id": "api",
+  "title": "Using npm programmatically"
+}, {
+  "id": "policies",
+  "title": "npm policy documents"
+}, {
+  "id": "company",
+  "title": "About npm inc"
+}]

--- a/test/index.js
+++ b/test/index.js
@@ -15,12 +15,12 @@ describe("content", function() {
     assert.equal(typeof content, 'object')
   })
 
-  it("is has a sections array", function() {
+  it("has a sections array", function() {
     assert(content.sections)
     assert(Array.isArray(content.sections))
   })
 
-  it("is has a pages array", function() {
+  it("has a pages array", function() {
     assert(content.pages)
     assert(Array.isArray(content.pages))
   })
@@ -111,6 +111,31 @@ describe("content", function() {
         assert(!iframe.attr("height"))
       })
     })
+
+    describe("edit_url", function() {
+
+      it("is always present", function() {
+        assert(content.pages.length)
+        content.pages.forEach(function(page){
+          assert(page.edit_url)
+        })
+      })
+
+      it("points pages in `api` section to the npm repo", function() {
+
+        var apiPages = content.pages.filter(function(page) {
+          return page.section === "api";
+        })
+        assert(apiPages.length)
+
+        apiPages.forEach(function(page){
+          assert.equal(page.edit_url, "https://github.com/npm/npm/edit/master/doc/" + page.filename)
+        })
+      })
+
+    })
+
+
 
   })
 

--- a/test/index.js
+++ b/test/index.js
@@ -63,7 +63,7 @@ describe("content", function() {
     it("always has content", function() {
       assert(content.pages.length)
       content.pages.forEach(function(page){
-        assert(page.content)
+        assert(page.content, page.filename + " has no content")
         assert.equal(typeof(page.content), "string")
       })
     })
@@ -89,53 +89,26 @@ describe("content", function() {
 
   })
 
-  describe("youtube videos", function() {
-    var iframeSelector = "div.youtube-video iframe"
-    var pagesWithYoutubes
+  describe("edit_url", function() {
 
-    before(function() {
-      pagesWithYoutubes = content.pages.filter(function(page) {
-        return cheerio.load(page.content)(iframeSelector).length > 0
+    it("is always present", function() {
+      assert(content.pages.length)
+      content.pages.forEach(function(page){
+        assert(page.edit_url)
       })
     })
 
-    it("wraps youtube iframes in a container element for stylability", function() {
-      assert(pagesWithYoutubes.length > 0)
-    })
+    it("points pages in `api` section to the npm repo", function() {
 
-    it("removes width and height property from youtube iframes", function() {
-      pagesWithYoutubes.forEach(function(page){
-        var iframe = cheerio.load(page.content)(iframeSelector)
-        assert(iframe.attr("src"))
-        assert(!iframe.attr("width"))
-        assert(!iframe.attr("height"))
+      var apiPages = content.pages.filter(function(page) {
+        return page.section === "api";
+      })
+      assert(apiPages.length)
+
+      apiPages.forEach(function(page){
+        assert.equal(page.edit_url, "https://github.com/npm/npm/edit/master/doc/" + page.filename)
       })
     })
-
-    describe("edit_url", function() {
-
-      it("is always present", function() {
-        assert(content.pages.length)
-        content.pages.forEach(function(page){
-          assert(page.edit_url)
-        })
-      })
-
-      it("points pages in `api` section to the npm repo", function() {
-
-        var apiPages = content.pages.filter(function(page) {
-          return page.section === "api";
-        })
-        assert(apiPages.length)
-
-        apiPages.forEach(function(page){
-          assert.equal(page.edit_url, "https://github.com/npm/npm/edit/master/doc/" + page.filename)
-        })
-      })
-
-    })
-
-
 
   })
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,5 @@
 var assert = require("assert")
+var path = require("path")
 var some = require("lodash").some
 var cheerio = require("cheerio")
 
@@ -73,6 +74,17 @@ describe("content", function() {
       content.pages.forEach(function(page){
         assert(page.modified)
         assert(page.modified.match(/\d{4}-\d{2}-/))
+      })
+    })
+
+    it("always has a URL-friendly filename", function() {
+      assert(content.pages.length)
+      content.pages.forEach(function(page){
+        assert.equal(
+          path.basename(page.filename),
+          encodeURIComponent(path.basename(page.filename)),
+          "page filename is not its encoded self: " + page.filename
+        )
       })
     })
 

--- a/views/layout.hbs
+++ b/views/layout.hbs
@@ -49,28 +49,30 @@
 
   <div class="toc">
     {{#each content.sections}}
-      {{#if pages.length}}
-        <section id="{{id}}">
+      {{#unless ignoreOnHomepage}}
+        {{#if pages.length}}
+          <section id="{{id}}">
 
-          <h2 title="{{title}}">
-            {{#if href}}
-              <a href="{{href}}">{{title}}</a>
-            {{else}}
-              {{title}}
-            {{/if}}
-          </h2>
+            <h2 title="{{title}}">
+              {{#if href}}
+                <a href="{{href}}">{{title}}</a>
+              {{else}}
+                {{title}}
+              {{/if}}
+            </h2>
 
-          <ul class="pageColumns">
-            {{#each pages}}
-              <li>
-                <a href="{{href}}">{{#if displayOrder}}{{order}} - {{/if}}{{title}}</a>
-                {{#if heading}}<span class="faint heading">{{heading}}</span>{{/if}}
-              </li>
-            {{/each}}
-          </ul>
+            <ul class="pageColumns">
+              {{#each pages}}
+                <li>
+                  <a href="{{href}}">{{#if displayOrder}}{{order}} - {{/if}}{{title}}</a>
+                  {{#if heading}}<span class="faint heading">{{heading}}</span>{{/if}}
+                </li>
+              {{/each}}
+            </ul>
 
-        </section>
-      {{/if}}
+          </section>
+        {{/if}}
+      {{/unless}}
     {{/each}}
     <section id="viewAll">
       <h2 title="View All">


### PR DESCRIPTION
[docs.npmjs.com](https://docs.npmjs.com) currently processes our [enterprise content](https://github.com/npm/docs.npmjs.com/tree/master/content/enterprise) and the [docs within the npm client](https://github.com/npm/npm/tree/master/doc), but I think it should be the tool that collects, transforms, and distributes **all of our markdown content**, whether it's getting started guides, API reference, product info, policies, static company pages, etc. Because docs.npmjs.com [is a cors-friendly JSON webservice](https://docs.npmjs.com/content.json), we can consume and display this content wherever we want: on the docs site, on newww, from the command line, in Dash.app...

There are many transformations that need to be applied to all of our markdown files, so it makes sense to do that work in one place:

- Run all HTML through the Caja sanitizer (as newww is currently doing for package READMEs), to remove malicious and/or erroneous HTML content.
- Apply syntax highlighting HTML and CSS to code blocks. Currently this is done browser-side on newww, which leads to an occasional flash-of-unstyled-code and adds 35K to the js bundle. Currently this syntax highlighting is not applied anywhere on docs.npmjs.com.
- Automatically add anchors to headings for deep linking within pages. This is not yet happening anywhere. 

That's all looking ahead, though.

Here are some proposed changes that bring us closer to that goal:

## Policies

@isaacs has expressed an interest in keeping the existing [policies repo](https://github.com/npm/policies) intact, so rather than moving content out of that repo, let's just `npm install` it in this one!

- Added a [package.json](https://github.com/npm/policies/blob/master/package.json) file to the policies repo, with a registry-2 style package name: `@npm/policies`
- Installed policies package from GitHub: `npm install npm/policies` because registry 2 is not ready
- Updated build script to copy markdown files from `./node_modules/@npm/policies/` to `./content/`

## Static Pages

There's a [static-pages repo](https://github.com/npm/static-pages) with one file in it: `jobs.md`. My proposal is to kill that repo in favor of `/content/company` in this repo.

##  Sections

I created a file called `sections.json` that allows the sections to be named and ordered. It looks like this:

```json
[{
  "id": "misc",
  "title": "Using npm"
}, {
  "id": "enterprise",
  "title": "npm Enterprise"
}, {
  "id": "cli",
  "title": "CLI Commands"
}, {
  "id": "files",
  "title": "Configuring npm"
}, {
  "id": "api",
  "title": "Using npm programmatically"
}, {
  "id": "policies",
  "title": "npm policy documents"
}, {
  "id": "company",
  "title": "About npm inc"
}]
```

If there are sections that we wish to disable on docs.npmjs.com (such as `company`), we can easily do so by including an additional property above and checking for it in the template.

@seldo, @linclark, @rockbot please tell me your thoughts.