### PR TITLE
scrap `text-transform` declarations

### DIFF
--- a/public/styles/_homepage.styl
+++ b/public/styles/_homepage.styl
@@ -25,4 +25,3 @@
     font-weight 400
     padding 0
     margin 15px 0 0 0
-    text-transform lowercase

--- a/public/styles/index.styl
+++ b/public/styles/index.styl
@@ -56,13 +56,11 @@ h1
   font-size 48px
   font-weight 600
   letter-spacing -0.6px
-  text-transform lowercase
   line-height 1.2
   padding 15px 0 0px 0
 
 h2
   font-size 24px
-  text-transform lowercase
   font-weight 600
   a
     color text-color
@@ -198,7 +196,6 @@ footer
   display none
 
   h2
-    text-transform lowercase
     centeredColumn homepageWidth
     margin-top 30px
     margin-bottom 10px


### PR DESCRIPTION
...because they mess up things like camelCased properties.

Fixes https://github.com/npm/docs.npmjs.com/issues/100