### PR TITLE
redirect old index file to homepage

### DIFF
--- a/lib/redirects.js
+++ b/lib/redirects.js
@@ -1,3 +1,4 @@
 module.exports = {
   "/enterprise/whitelist": "/enterprise/mirroring",
+  "/misc/index": "/",
 }

--- a/test/server.js
+++ b/test/server.js
@@ -67,10 +67,18 @@ describe('GET /cli/nonexistent', function() {
 
 describe('redirects', function() {
 
-  it('301s whitelist to mirroring', function(done) {
+  it('301s /enterprise/whitelist to /enterprise/mirroring', function(done) {
     supertest(app)
       .get('/enterprise/whitelist')
-      .expect('Location', /\/enterprise\/mirroring/)
+      .expect('Location', /\/enterprise\/mirroring$/)
       .expect(301, done)
   })
+
+  it('301s /misc/index to /', function(done) {
+    supertest(app)
+      .get('/misc/index')
+      .expect('Location', /\/$/)
+      .expect(301, done)
+  })
+
 })


### PR DESCRIPTION
This page is now a less-good version of the docs homepage: https://docs.npmjs.com/misc/index -- let's kill it and redirect to `/` instead. This PR paves the way for https://github.com/npm/docs.npmjs.com/pull/103