### PR TITLE
Remove `sudo` from update instructions

### DIFF
--- a/content/getting-started/installing-node.md
+++ b/content/getting-started/installing-node.md
@@ -17,6 +17,6 @@ Test: Run `node -v`. The version should be higher than v0.10.32.
 
 Node comes with npm installed so you should have a version of npm. However, npm gets updated more frequently than Node does, so you'll want to make sure it's the latest version.
 
-`sudo npm install npm -g`.
+`npm install npm -g`.
 
 Test: Run `npm -v`. The version should be higher than 2.1.8.


### PR DESCRIPTION
`sudo` should not be required for a user developing with node or npm, and in fact will likely cause confusion (why are some of my files unchangeable?) and simply introduce a serious security issue on the developers computer (writing a malicious npm package would be trivial).

This only removes the suggestion from the getting started update guide.